### PR TITLE
feat(packs): add missing pack bundles

### DIFF
--- a/docs/packs-roadmap.md
+++ b/docs/packs-roadmap.md
@@ -146,28 +146,28 @@ Status legend: `in-repo` means a pack exists in this repository.
 ### Phase 1 (Foundation)
 - mcp-client: Cordum as an MCP client; `read|write|network` (status: in-repo)
 - github: repo read/search, issues, PRs, checks, releases (status: in-repo)
-- slack: notifications, approvals, incident channels
-- jira: issues, transitions, comments, attachments
-- webhooks: inbound events to start workflows; principal mapping required
-- kubernetes-triage: diagnostics, events, logs, rollout status
+- slack: notifications, approvals, incident channels (status: in-repo)
+- jira: issues, transitions, comments, attachments (status: in-repo)
+- webhooks: inbound events to start workflows; principal mapping required (status: in-repo)
+- kubernetes-triage: diagnostics, events, logs, rollout status (status: in-repo)
 
 ### Phase 2 (Ops and Observability)
-- prometheus-query: PromQL queries and alert state
-- datadog: metrics/logs/traces queries; monitor changes require approval
-- pagerduty: on-call schedules, incidents, escalations
-- servicenow: ITSM incidents/changes/CMDB; `prod` and `write` tagging
-- msteams: Teams-native notifications and approvals
-- sentry: issues, releases, suspect commits
-- opentelemetry: trace search and dependency graphs (read-only early)
+- prometheus-query: PromQL queries and alert state (status: in-repo)
+- datadog: metrics/logs/traces queries; monitor changes require approval (status: in-repo)
+- pagerduty: on-call schedules, incidents, escalations (status: in-repo)
+- servicenow: ITSM incidents/changes/CMDB; `prod` and `write` tagging (status: in-repo)
+- msteams: Teams-native notifications and approvals (status: in-repo)
+- sentry: issues, releases, suspect commits (status: in-repo)
+- opentelemetry: trace search and dependency graphs (read-only early) (status: in-repo)
 
 ### Phase 3 (Infra and Change)
-- aws: CloudWatch logs/metrics, ECS/EKS inspection, S3 evidence
-- gcp: Cloud Logging/Monitoring queries, GKE inspection
-- azure: Azure Monitor queries, AKS inspection
-- terraform: plan, drift detection, policy checks; apply requires approval
-- vault: secret resolution and dynamic credentials; no raw secrets in workflows
-- gitlab: repo read/search, merge requests, pipelines, issues
-- cron-triggers: scheduled runs for checks, summaries, compliance
+- aws: CloudWatch logs/metrics, ECS/EKS inspection, S3 evidence (status: in-repo)
+- gcp: Cloud Logging/Monitoring queries, GKE inspection (status: in-repo)
+- azure: Azure Monitor queries, AKS inspection (status: in-repo)
+- terraform: plan, drift detection, policy checks; apply requires approval (status: in-repo)
+- vault: secret resolution and dynamic credentials; no raw secrets in workflows (status: in-repo)
+- gitlab: repo read/search, merge requests, pipelines, issues (status: in-repo)
+- cron-triggers: scheduled runs for checks, summaries, compliance (status: in-repo)
 
 ## Governance Checklist (Per Pack)
 

--- a/packs/aws/pack/overlays/policy.fragment.yaml
+++ b/packs/aws/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: aws-read
+    match:
+      topics:
+        - job.aws.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: aws-write
+    match:
+      topics:
+        - job.aws.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "AWS write actions require approval"

--- a/packs/aws/pack/overlays/pools.patch.yaml
+++ b/packs/aws/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.aws.read: aws
+  job.aws.write: aws
+pools:
+  aws:
+    requires: ["network:egress"]

--- a/packs/aws/pack/overlays/timeouts.patch.yaml
+++ b/packs/aws/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.aws.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.aws.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/aws/pack/pack.yaml
+++ b/packs/aws/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: aws
+  version: 0.1.0
+  title: AWS
+  description: AWS observability and inspection actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.aws.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: aws.read
+
+  - name: job.aws.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: aws.write
+
+resources:
+  schemas:
+    - id: aws/AWSActionInput
+      path: schemas/AWSActionInput.json
+    - id: aws/AWSActionResult
+      path: schemas/AWSActionResult.json
+  workflows:
+    - id: aws.read
+      path: workflows/aws_read.yaml
+    - id: aws.write
+      path: workflows/aws_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.aws.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.aws.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/aws/pack/schemas/AWSActionInput.json
+++ b/packs/aws/pack/schemas/AWSActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AWS Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. cloudwatch.logs.query, ecs.services.list, s3.get_object."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/aws/pack/schemas/AWSActionResult.json
+++ b/packs/aws/pack/schemas/AWSActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AWS Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/aws/pack/workflows/aws_read.yaml
+++ b/packs/aws/pack/workflows/aws_read.yaml
@@ -1,0 +1,23 @@
+id: aws.read
+name: AWS Read
+description: Read AWS logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: AWS Read action
+    type: worker
+    topic: job.aws.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: aws/AWSActionInput
+    output_schema_id: aws/AWSActionResult
+    meta:
+      pack_id: aws
+      capability: aws.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/aws/pack/workflows/aws_write.yaml
+++ b/packs/aws/pack/workflows/aws_write.yaml
@@ -1,0 +1,23 @@
+id: aws.write
+name: AWS Write
+description: Perform approved AWS changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: AWS Write action
+    type: worker
+    topic: job.aws.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: aws/AWSActionInput
+    output_schema_id: aws/AWSActionResult
+    meta:
+      pack_id: aws
+      capability: aws.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/azure/pack/overlays/policy.fragment.yaml
+++ b/packs/azure/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: azure-read
+    match:
+      topics:
+        - job.azure.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: azure-write
+    match:
+      topics:
+        - job.azure.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Azure write actions require approval"

--- a/packs/azure/pack/overlays/pools.patch.yaml
+++ b/packs/azure/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.azure.read: azure
+  job.azure.write: azure
+pools:
+  azure:
+    requires: ["network:egress"]

--- a/packs/azure/pack/overlays/timeouts.patch.yaml
+++ b/packs/azure/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.azure.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.azure.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/azure/pack/pack.yaml
+++ b/packs/azure/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: azure
+  version: 0.1.0
+  title: Azure
+  description: Azure Monitor queries and service inspection.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.azure.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: azure.read
+
+  - name: job.azure.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: azure.write
+
+resources:
+  schemas:
+    - id: azure/AzureActionInput
+      path: schemas/AzureActionInput.json
+    - id: azure/AzureActionResult
+      path: schemas/AzureActionResult.json
+  workflows:
+    - id: azure.read
+      path: workflows/azure_read.yaml
+    - id: azure.write
+      path: workflows/azure_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.azure.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.azure.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/azure/pack/schemas/AzureActionInput.json
+++ b/packs/azure/pack/schemas/AzureActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Azure Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. monitor.metrics.list, monitor.logs.query, aks.clusters.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/azure/pack/schemas/AzureActionResult.json
+++ b/packs/azure/pack/schemas/AzureActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Azure Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/azure/pack/workflows/azure_read.yaml
+++ b/packs/azure/pack/workflows/azure_read.yaml
@@ -1,0 +1,23 @@
+id: azure.read
+name: Azure Read
+description: Read Azure logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Azure Read action
+    type: worker
+    topic: job.azure.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: azure/AzureActionInput
+    output_schema_id: azure/AzureActionResult
+    meta:
+      pack_id: azure
+      capability: azure.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/azure/pack/workflows/azure_write.yaml
+++ b/packs/azure/pack/workflows/azure_write.yaml
@@ -1,0 +1,23 @@
+id: azure.write
+name: Azure Write
+description: Perform approved Azure changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Azure Write action
+    type: worker
+    topic: job.azure.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: azure/AzureActionInput
+    output_schema_id: azure/AzureActionResult
+    meta:
+      pack_id: azure
+      capability: azure.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/cron-triggers/pack/overlays/policy.fragment.yaml
+++ b/packs/cron-triggers/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: cron-triggers-read
+    match:
+      topics:
+        - job.cron-triggers.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: cron-triggers-write
+    match:
+      topics:
+        - job.cron-triggers.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Cron Triggers write actions require approval"

--- a/packs/cron-triggers/pack/overlays/pools.patch.yaml
+++ b/packs/cron-triggers/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.cron-triggers.read: cron-triggers
+  job.cron-triggers.write: cron-triggers
+pools:
+  cron-triggers:
+    requires: []

--- a/packs/cron-triggers/pack/overlays/timeouts.patch.yaml
+++ b/packs/cron-triggers/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.cron-triggers.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.cron-triggers.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/cron-triggers/pack/pack.yaml
+++ b/packs/cron-triggers/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: cron-triggers
+  version: 0.1.0
+  title: Cron Triggers
+  description: Scheduled runs that trigger Cordum workflows.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.cron-triggers.read
+    requires: []
+    riskTags: ["read"]
+    capability: cron-triggers.read
+
+  - name: job.cron-triggers.write
+    requires: []
+    riskTags: ["write"]
+    capability: cron-triggers.write
+
+resources:
+  schemas:
+    - id: cron-triggers/CronTriggersActionInput
+      path: schemas/CronTriggersActionInput.json
+    - id: cron-triggers/CronTriggersActionResult
+      path: schemas/CronTriggersActionResult.json
+  workflows:
+    - id: cron-triggers.read
+      path: workflows/cron_triggers_read.yaml
+    - id: cron-triggers.write
+      path: workflows/cron_triggers_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.cron-triggers.read
+        riskTags: ["read"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.cron-triggers.write
+        riskTags: ["write"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/cron-triggers/pack/schemas/CronTriggersActionInput.json
+++ b/packs/cron-triggers/pack/schemas/CronTriggersActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CronTriggers Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. schedules.list, schedules.create, schedules.delete."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/cron-triggers/pack/schemas/CronTriggersActionResult.json
+++ b/packs/cron-triggers/pack/schemas/CronTriggersActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CronTriggers Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/cron-triggers/pack/workflows/cron_triggers_read.yaml
+++ b/packs/cron-triggers/pack/workflows/cron_triggers_read.yaml
@@ -1,0 +1,23 @@
+id: cron-triggers.read
+name: Cron Triggers Read
+description: List or inspect scheduled runs.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Cron Triggers Read action
+    type: worker
+    topic: job.cron-triggers.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: cron-triggers/CronTriggersActionInput
+    output_schema_id: cron-triggers/CronTriggersActionResult
+    meta:
+      pack_id: cron-triggers
+      capability: cron-triggers.read
+      risk_tags: ["read"]
+      requires: []

--- a/packs/cron-triggers/pack/workflows/cron_triggers_write.yaml
+++ b/packs/cron-triggers/pack/workflows/cron_triggers_write.yaml
@@ -1,0 +1,23 @@
+id: cron-triggers.write
+name: Cron Triggers Write
+description: Create or update scheduled runs.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Cron Triggers Write action
+    type: worker
+    topic: job.cron-triggers.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: cron-triggers/CronTriggersActionInput
+    output_schema_id: cron-triggers/CronTriggersActionResult
+    meta:
+      pack_id: cron-triggers
+      capability: cron-triggers.write
+      risk_tags: ["write"]
+      requires: []

--- a/packs/datadog/pack/overlays/policy.fragment.yaml
+++ b/packs/datadog/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: datadog-read
+    match:
+      topics:
+        - job.datadog.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: datadog-write
+    match:
+      topics:
+        - job.datadog.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Datadog write actions require approval"

--- a/packs/datadog/pack/overlays/pools.patch.yaml
+++ b/packs/datadog/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.datadog.read: datadog
+  job.datadog.write: datadog
+pools:
+  datadog:
+    requires: ["network:egress"]

--- a/packs/datadog/pack/overlays/timeouts.patch.yaml
+++ b/packs/datadog/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.datadog.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.datadog.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/datadog/pack/pack.yaml
+++ b/packs/datadog/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: datadog
+  version: 0.1.0
+  title: Datadog
+  description: Datadog metrics, logs, traces, and monitor actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.datadog.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: datadog.read
+
+  - name: job.datadog.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: datadog.write
+
+resources:
+  schemas:
+    - id: datadog/DatadogActionInput
+      path: schemas/DatadogActionInput.json
+    - id: datadog/DatadogActionResult
+      path: schemas/DatadogActionResult.json
+  workflows:
+    - id: datadog.read
+      path: workflows/datadog_read.yaml
+    - id: datadog.write
+      path: workflows/datadog_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.datadog.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.datadog.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/datadog/pack/schemas/DatadogActionInput.json
+++ b/packs/datadog/pack/schemas/DatadogActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Datadog Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. metrics.query, logs.search, monitors.mute."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/datadog/pack/schemas/DatadogActionResult.json
+++ b/packs/datadog/pack/schemas/DatadogActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Datadog Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/datadog/pack/workflows/datadog_read.yaml
+++ b/packs/datadog/pack/workflows/datadog_read.yaml
@@ -1,0 +1,23 @@
+id: datadog.read
+name: Datadog Read
+description: Query Datadog metrics, logs, and traces.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Datadog Read action
+    type: worker
+    topic: job.datadog.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: datadog/DatadogActionInput
+    output_schema_id: datadog/DatadogActionResult
+    meta:
+      pack_id: datadog
+      capability: datadog.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/datadog/pack/workflows/datadog_write.yaml
+++ b/packs/datadog/pack/workflows/datadog_write.yaml
@@ -1,0 +1,23 @@
+id: datadog.write
+name: Datadog Write
+description: Mute or update Datadog monitors with approvals.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Datadog Write action
+    type: worker
+    topic: job.datadog.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: datadog/DatadogActionInput
+    output_schema_id: datadog/DatadogActionResult
+    meta:
+      pack_id: datadog
+      capability: datadog.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/gcp/pack/overlays/policy.fragment.yaml
+++ b/packs/gcp/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: gcp-read
+    match:
+      topics:
+        - job.gcp.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: gcp-write
+    match:
+      topics:
+        - job.gcp.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "GCP write actions require approval"

--- a/packs/gcp/pack/overlays/pools.patch.yaml
+++ b/packs/gcp/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.gcp.read: gcp
+  job.gcp.write: gcp
+pools:
+  gcp:
+    requires: ["network:egress"]

--- a/packs/gcp/pack/overlays/timeouts.patch.yaml
+++ b/packs/gcp/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.gcp.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.gcp.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/gcp/pack/pack.yaml
+++ b/packs/gcp/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: gcp
+  version: 0.1.0
+  title: GCP
+  description: GCP logging/monitoring queries and service inspection.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.gcp.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: gcp.read
+
+  - name: job.gcp.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: gcp.write
+
+resources:
+  schemas:
+    - id: gcp/GCPActionInput
+      path: schemas/GCPActionInput.json
+    - id: gcp/GCPActionResult
+      path: schemas/GCPActionResult.json
+  workflows:
+    - id: gcp.read
+      path: workflows/gcp_read.yaml
+    - id: gcp.write
+      path: workflows/gcp_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.gcp.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.gcp.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/gcp/pack/schemas/GCPActionInput.json
+++ b/packs/gcp/pack/schemas/GCPActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GCP Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. logging.entries.list, monitoring.timeSeries.list, gke.clusters.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/gcp/pack/schemas/GCPActionResult.json
+++ b/packs/gcp/pack/schemas/GCPActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GCP Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/gcp/pack/workflows/gcp_read.yaml
+++ b/packs/gcp/pack/workflows/gcp_read.yaml
@@ -1,0 +1,23 @@
+id: gcp.read
+name: GCP Read
+description: Read GCP logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: GCP Read action
+    type: worker
+    topic: job.gcp.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gcp/GCPActionInput
+    output_schema_id: gcp/GCPActionResult
+    meta:
+      pack_id: gcp
+      capability: gcp.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/gcp/pack/workflows/gcp_write.yaml
+++ b/packs/gcp/pack/workflows/gcp_write.yaml
@@ -1,0 +1,23 @@
+id: gcp.write
+name: GCP Write
+description: Perform approved GCP changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: GCP Write action
+    type: worker
+    topic: job.gcp.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gcp/GCPActionInput
+    output_schema_id: gcp/GCPActionResult
+    meta:
+      pack_id: gcp
+      capability: gcp.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/gitlab/pack/overlays/policy.fragment.yaml
+++ b/packs/gitlab/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: gitlab-read
+    match:
+      topics:
+        - job.gitlab.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: gitlab-write
+    match:
+      topics:
+        - job.gitlab.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "GitLab write actions require approval"

--- a/packs/gitlab/pack/overlays/pools.patch.yaml
+++ b/packs/gitlab/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.gitlab.read: gitlab
+  job.gitlab.write: gitlab
+pools:
+  gitlab:
+    requires: ["network:egress"]

--- a/packs/gitlab/pack/overlays/timeouts.patch.yaml
+++ b/packs/gitlab/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.gitlab.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.gitlab.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/gitlab/pack/pack.yaml
+++ b/packs/gitlab/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: gitlab
+  version: 0.1.0
+  title: GitLab
+  description: GitLab repo, merge request, pipeline, and issue automation.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.gitlab.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: gitlab.read
+
+  - name: job.gitlab.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: gitlab.write
+
+resources:
+  schemas:
+    - id: gitlab/GitLabActionInput
+      path: schemas/GitLabActionInput.json
+    - id: gitlab/GitLabActionResult
+      path: schemas/GitLabActionResult.json
+  workflows:
+    - id: gitlab.read
+      path: workflows/gitlab_read.yaml
+    - id: gitlab.write
+      path: workflows/gitlab_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.gitlab.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.gitlab.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/gitlab/pack/schemas/GitLabActionInput.json
+++ b/packs/gitlab/pack/schemas/GitLabActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GitLab Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. projects.list, issues.create, merge_requests.create."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/gitlab/pack/schemas/GitLabActionResult.json
+++ b/packs/gitlab/pack/schemas/GitLabActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GitLab Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/gitlab/pack/workflows/gitlab_read.yaml
+++ b/packs/gitlab/pack/workflows/gitlab_read.yaml
@@ -1,0 +1,23 @@
+id: gitlab.read
+name: GitLab Read
+description: Fetch GitLab project, issue, or merge request data.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: GitLab Read action
+    type: worker
+    topic: job.gitlab.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gitlab/GitLabActionInput
+    output_schema_id: gitlab/GitLabActionResult
+    meta:
+      pack_id: gitlab
+      capability: gitlab.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/gitlab/pack/workflows/gitlab_write.yaml
+++ b/packs/gitlab/pack/workflows/gitlab_write.yaml
@@ -1,0 +1,23 @@
+id: gitlab.write
+name: GitLab Write
+description: Create or update GitLab issues or merge requests.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: GitLab Write action
+    type: worker
+    topic: job.gitlab.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gitlab/GitLabActionInput
+    output_schema_id: gitlab/GitLabActionResult
+    meta:
+      pack_id: gitlab
+      capability: gitlab.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/msteams/pack/overlays/policy.fragment.yaml
+++ b/packs/msteams/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: msteams-read
+    match:
+      topics:
+        - job.msteams.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: msteams-write
+    match:
+      topics:
+        - job.msteams.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Microsoft Teams write actions require approval"

--- a/packs/msteams/pack/overlays/pools.patch.yaml
+++ b/packs/msteams/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.msteams.read: msteams
+  job.msteams.write: msteams
+pools:
+  msteams:
+    requires: ["network:egress"]

--- a/packs/msteams/pack/overlays/timeouts.patch.yaml
+++ b/packs/msteams/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.msteams.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.msteams.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/msteams/pack/pack.yaml
+++ b/packs/msteams/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: msteams
+  version: 0.1.0
+  title: Microsoft Teams
+  description: Teams notifications and approvals for enterprise ChatOps.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.msteams.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: msteams.read
+
+  - name: job.msteams.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: msteams.write
+
+resources:
+  schemas:
+    - id: msteams/MSTeamsActionInput
+      path: schemas/MSTeamsActionInput.json
+    - id: msteams/MSTeamsActionResult
+      path: schemas/MSTeamsActionResult.json
+  workflows:
+    - id: msteams.read
+      path: workflows/msteams_read.yaml
+    - id: msteams.write
+      path: workflows/msteams_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.msteams.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.msteams.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/msteams/pack/schemas/MSTeamsActionInput.json
+++ b/packs/msteams/pack/schemas/MSTeamsActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MSTeams Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. teams.list, channels.list, messages.post."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/msteams/pack/schemas/MSTeamsActionResult.json
+++ b/packs/msteams/pack/schemas/MSTeamsActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MSTeams Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/msteams/pack/workflows/msteams_read.yaml
+++ b/packs/msteams/pack/workflows/msteams_read.yaml
@@ -1,0 +1,23 @@
+id: msteams.read
+name: Microsoft Teams Read
+description: Read Teams or channel metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Microsoft Teams Read action
+    type: worker
+    topic: job.msteams.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: msteams/MSTeamsActionInput
+    output_schema_id: msteams/MSTeamsActionResult
+    meta:
+      pack_id: msteams
+      capability: msteams.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/msteams/pack/workflows/msteams_write.yaml
+++ b/packs/msteams/pack/workflows/msteams_write.yaml
@@ -1,0 +1,23 @@
+id: msteams.write
+name: Microsoft Teams Write
+description: Post Teams messages or approvals.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Microsoft Teams Write action
+    type: worker
+    topic: job.msteams.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: msteams/MSTeamsActionInput
+    output_schema_id: msteams/MSTeamsActionResult
+    meta:
+      pack_id: msteams
+      capability: msteams.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/opentelemetry/pack/overlays/policy.fragment.yaml
+++ b/packs/opentelemetry/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,9 @@
+version: v1
+rules:
+  - id: opentelemetry-read
+    match:
+      topics:
+        - job.opentelemetry.read
+      risk_tags:
+        - read
+    decision: allow

--- a/packs/opentelemetry/pack/overlays/pools.patch.yaml
+++ b/packs/opentelemetry/pack/overlays/pools.patch.yaml
@@ -1,0 +1,5 @@
+topics:
+  job.opentelemetry.read: opentelemetry
+pools:
+  opentelemetry:
+    requires: ["network:egress"]

--- a/packs/opentelemetry/pack/overlays/timeouts.patch.yaml
+++ b/packs/opentelemetry/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,4 @@
+topics:
+  job.opentelemetry.read:
+    timeout_seconds: 60
+    max_retries: 2

--- a/packs/opentelemetry/pack/pack.yaml
+++ b/packs/opentelemetry/pack/pack.yaml
@@ -1,0 +1,54 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: opentelemetry
+  version: 0.1.0
+  title: OpenTelemetry
+  description: Trace search and dependency insights via OTel backends.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.opentelemetry.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: opentelemetry.read
+
+resources:
+  schemas:
+    - id: opentelemetry/OpenTelemetryActionInput
+      path: schemas/OpenTelemetryActionInput.json
+    - id: opentelemetry/OpenTelemetryActionResult
+      path: schemas/OpenTelemetryActionResult.json
+  workflows:
+    - id: opentelemetry.read
+      path: workflows/opentelemetry_read.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.opentelemetry.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW

--- a/packs/opentelemetry/pack/schemas/OpenTelemetryActionInput.json
+++ b/packs/opentelemetry/pack/schemas/OpenTelemetryActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenTelemetry Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. traces.search, services.list, dependencies.graph."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/opentelemetry/pack/schemas/OpenTelemetryActionResult.json
+++ b/packs/opentelemetry/pack/schemas/OpenTelemetryActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenTelemetry Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/opentelemetry/pack/workflows/opentelemetry_read.yaml
+++ b/packs/opentelemetry/pack/workflows/opentelemetry_read.yaml
@@ -1,0 +1,23 @@
+id: opentelemetry.read
+name: OpenTelemetry Read
+description: Search traces and service dependencies.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: OpenTelemetry Read action
+    type: worker
+    topic: job.opentelemetry.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: opentelemetry/OpenTelemetryActionInput
+    output_schema_id: opentelemetry/OpenTelemetryActionResult
+    meta:
+      pack_id: opentelemetry
+      capability: opentelemetry.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/pagerduty/pack/overlays/policy.fragment.yaml
+++ b/packs/pagerduty/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: pagerduty-read
+    match:
+      topics:
+        - job.pagerduty.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: pagerduty-write
+    match:
+      topics:
+        - job.pagerduty.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "PagerDuty write actions require approval"

--- a/packs/pagerduty/pack/overlays/pools.patch.yaml
+++ b/packs/pagerduty/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.pagerduty.read: pagerduty
+  job.pagerduty.write: pagerduty
+pools:
+  pagerduty:
+    requires: ["network:egress"]

--- a/packs/pagerduty/pack/overlays/timeouts.patch.yaml
+++ b/packs/pagerduty/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.pagerduty.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.pagerduty.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/pagerduty/pack/pack.yaml
+++ b/packs/pagerduty/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: pagerduty
+  version: 0.1.0
+  title: PagerDuty
+  description: PagerDuty incident and on-call actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.pagerduty.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: pagerduty.read
+
+  - name: job.pagerduty.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: pagerduty.write
+
+resources:
+  schemas:
+    - id: pagerduty/PagerDutyActionInput
+      path: schemas/PagerDutyActionInput.json
+    - id: pagerduty/PagerDutyActionResult
+      path: schemas/PagerDutyActionResult.json
+  workflows:
+    - id: pagerduty.read
+      path: workflows/pagerduty_read.yaml
+    - id: pagerduty.write
+      path: workflows/pagerduty_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.pagerduty.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.pagerduty.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/pagerduty/pack/schemas/PagerDutyActionInput.json
+++ b/packs/pagerduty/pack/schemas/PagerDutyActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PagerDuty Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. incidents.list, incidents.resolve, schedules.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/pagerduty/pack/schemas/PagerDutyActionResult.json
+++ b/packs/pagerduty/pack/schemas/PagerDutyActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PagerDuty Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/pagerduty/pack/workflows/pagerduty_read.yaml
+++ b/packs/pagerduty/pack/workflows/pagerduty_read.yaml
@@ -1,0 +1,23 @@
+id: pagerduty.read
+name: PagerDuty Read
+description: Read PagerDuty incidents and on-call schedules.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: PagerDuty Read action
+    type: worker
+    topic: job.pagerduty.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: pagerduty/PagerDutyActionInput
+    output_schema_id: pagerduty/PagerDutyActionResult
+    meta:
+      pack_id: pagerduty
+      capability: pagerduty.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/pagerduty/pack/workflows/pagerduty_write.yaml
+++ b/packs/pagerduty/pack/workflows/pagerduty_write.yaml
@@ -1,0 +1,23 @@
+id: pagerduty.write
+name: PagerDuty Write
+description: Acknowledge or resolve PagerDuty incidents.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: PagerDuty Write action
+    type: worker
+    topic: job.pagerduty.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: pagerduty/PagerDutyActionInput
+    output_schema_id: pagerduty/PagerDutyActionResult
+    meta:
+      pack_id: pagerduty
+      capability: pagerduty.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/prometheus-query/pack/overlays/policy.fragment.yaml
+++ b/packs/prometheus-query/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,9 @@
+version: v1
+rules:
+  - id: prometheus-query-read
+    match:
+      topics:
+        - job.prometheus-query.read
+      risk_tags:
+        - read
+    decision: allow

--- a/packs/prometheus-query/pack/overlays/pools.patch.yaml
+++ b/packs/prometheus-query/pack/overlays/pools.patch.yaml
@@ -1,0 +1,5 @@
+topics:
+  job.prometheus-query.read: prometheus-query
+pools:
+  prometheus-query:
+    requires: ["network:egress"]

--- a/packs/prometheus-query/pack/overlays/timeouts.patch.yaml
+++ b/packs/prometheus-query/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,4 @@
+topics:
+  job.prometheus-query.read:
+    timeout_seconds: 60
+    max_retries: 2

--- a/packs/prometheus-query/pack/pack.yaml
+++ b/packs/prometheus-query/pack/pack.yaml
@@ -1,0 +1,54 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: prometheus-query
+  version: 0.1.0
+  title: Prometheus Query
+  description: PromQL queries, alert state, and label discovery.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.prometheus-query.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: prometheus-query.read
+
+resources:
+  schemas:
+    - id: prometheus-query/PrometheusQueryActionInput
+      path: schemas/PrometheusQueryActionInput.json
+    - id: prometheus-query/PrometheusQueryActionResult
+      path: schemas/PrometheusQueryActionResult.json
+  workflows:
+    - id: prometheus-query.read
+      path: workflows/prometheus_query_read.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.prometheus-query.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW

--- a/packs/prometheus-query/pack/schemas/PrometheusQueryActionInput.json
+++ b/packs/prometheus-query/pack/schemas/PrometheusQueryActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PrometheusQuery Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. query.instant, query.range, alerts.list."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/prometheus-query/pack/schemas/PrometheusQueryActionResult.json
+++ b/packs/prometheus-query/pack/schemas/PrometheusQueryActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PrometheusQuery Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/prometheus-query/pack/workflows/prometheus_query_read.yaml
+++ b/packs/prometheus-query/pack/workflows/prometheus_query_read.yaml
@@ -1,0 +1,23 @@
+id: prometheus-query.read
+name: Prometheus Query Read
+description: Run Prometheus queries and inspect alert state.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Prometheus Query Read action
+    type: worker
+    topic: job.prometheus-query.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: prometheus-query/PrometheusQueryActionInput
+    output_schema_id: prometheus-query/PrometheusQueryActionResult
+    meta:
+      pack_id: prometheus-query
+      capability: prometheus-query.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/sentry/pack/overlays/policy.fragment.yaml
+++ b/packs/sentry/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: sentry-read
+    match:
+      topics:
+        - job.sentry.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: sentry-write
+    match:
+      topics:
+        - job.sentry.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Sentry write actions require approval"

--- a/packs/sentry/pack/overlays/pools.patch.yaml
+++ b/packs/sentry/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.sentry.read: sentry
+  job.sentry.write: sentry
+pools:
+  sentry:
+    requires: ["network:egress"]

--- a/packs/sentry/pack/overlays/timeouts.patch.yaml
+++ b/packs/sentry/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.sentry.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.sentry.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/sentry/pack/pack.yaml
+++ b/packs/sentry/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: sentry
+  version: 0.1.0
+  title: Sentry
+  description: Sentry issues, releases, and alert routing actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.sentry.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: sentry.read
+
+  - name: job.sentry.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: sentry.write
+
+resources:
+  schemas:
+    - id: sentry/SentryActionInput
+      path: schemas/SentryActionInput.json
+    - id: sentry/SentryActionResult
+      path: schemas/SentryActionResult.json
+  workflows:
+    - id: sentry.read
+      path: workflows/sentry_read.yaml
+    - id: sentry.write
+      path: workflows/sentry_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.sentry.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.sentry.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/sentry/pack/schemas/SentryActionInput.json
+++ b/packs/sentry/pack/schemas/SentryActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Sentry Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. issues.list, issues.resolve, releases.list."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/sentry/pack/schemas/SentryActionResult.json
+++ b/packs/sentry/pack/schemas/SentryActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Sentry Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/sentry/pack/workflows/sentry_read.yaml
+++ b/packs/sentry/pack/workflows/sentry_read.yaml
@@ -1,0 +1,23 @@
+id: sentry.read
+name: Sentry Read
+description: Read Sentry issues and release data.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Sentry Read action
+    type: worker
+    topic: job.sentry.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: sentry/SentryActionInput
+    output_schema_id: sentry/SentryActionResult
+    meta:
+      pack_id: sentry
+      capability: sentry.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/sentry/pack/workflows/sentry_write.yaml
+++ b/packs/sentry/pack/workflows/sentry_write.yaml
@@ -1,0 +1,23 @@
+id: sentry.write
+name: Sentry Write
+description: Resolve or update Sentry issues with approvals.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Sentry Write action
+    type: worker
+    topic: job.sentry.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: sentry/SentryActionInput
+    output_schema_id: sentry/SentryActionResult
+    meta:
+      pack_id: sentry
+      capability: sentry.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/servicenow/pack/overlays/policy.fragment.yaml
+++ b/packs/servicenow/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: servicenow-read
+    match:
+      topics:
+        - job.servicenow.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: servicenow-write
+    match:
+      topics:
+        - job.servicenow.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "ServiceNow write actions require approval"

--- a/packs/servicenow/pack/overlays/pools.patch.yaml
+++ b/packs/servicenow/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.servicenow.read: servicenow
+  job.servicenow.write: servicenow
+pools:
+  servicenow:
+    requires: ["network:egress"]

--- a/packs/servicenow/pack/overlays/timeouts.patch.yaml
+++ b/packs/servicenow/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.servicenow.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.servicenow.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/servicenow/pack/pack.yaml
+++ b/packs/servicenow/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: servicenow
+  version: 0.1.0
+  title: ServiceNow
+  description: ServiceNow incidents, changes, and CMDB actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.servicenow.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: servicenow.read
+
+  - name: job.servicenow.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: servicenow.write
+
+resources:
+  schemas:
+    - id: servicenow/ServiceNowActionInput
+      path: schemas/ServiceNowActionInput.json
+    - id: servicenow/ServiceNowActionResult
+      path: schemas/ServiceNowActionResult.json
+  workflows:
+    - id: servicenow.read
+      path: workflows/servicenow_read.yaml
+    - id: servicenow.write
+      path: workflows/servicenow_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.servicenow.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.servicenow.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/servicenow/pack/schemas/ServiceNowActionInput.json
+++ b/packs/servicenow/pack/schemas/ServiceNowActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ServiceNow Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. incidents.get, incidents.create, changes.create."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/servicenow/pack/schemas/ServiceNowActionResult.json
+++ b/packs/servicenow/pack/schemas/ServiceNowActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ServiceNow Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/servicenow/pack/workflows/servicenow_read.yaml
+++ b/packs/servicenow/pack/workflows/servicenow_read.yaml
@@ -1,0 +1,23 @@
+id: servicenow.read
+name: ServiceNow Read
+description: Read ServiceNow incidents and CMDB records.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: ServiceNow Read action
+    type: worker
+    topic: job.servicenow.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: servicenow/ServiceNowActionInput
+    output_schema_id: servicenow/ServiceNowActionResult
+    meta:
+      pack_id: servicenow
+      capability: servicenow.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/servicenow/pack/workflows/servicenow_write.yaml
+++ b/packs/servicenow/pack/workflows/servicenow_write.yaml
@@ -1,0 +1,23 @@
+id: servicenow.write
+name: ServiceNow Write
+description: Create or update ServiceNow incidents and changes.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: ServiceNow Write action
+    type: worker
+    topic: job.servicenow.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: servicenow/ServiceNowActionInput
+    output_schema_id: servicenow/ServiceNowActionResult
+    meta:
+      pack_id: servicenow
+      capability: servicenow.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/terraform/pack/overlays/policy.fragment.yaml
+++ b/packs/terraform/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: terraform-read
+    match:
+      topics:
+        - job.terraform.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: terraform-write
+    match:
+      topics:
+        - job.terraform.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Terraform write actions require approval"

--- a/packs/terraform/pack/overlays/pools.patch.yaml
+++ b/packs/terraform/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.terraform.read: terraform
+  job.terraform.write: terraform
+pools:
+  terraform:
+    requires: ["network:egress"]

--- a/packs/terraform/pack/overlays/timeouts.patch.yaml
+++ b/packs/terraform/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.terraform.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.terraform.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/terraform/pack/pack.yaml
+++ b/packs/terraform/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: terraform
+  version: 0.1.0
+  title: Terraform
+  description: Terraform plan and apply workflows with approvals.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.terraform.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: terraform.read
+
+  - name: job.terraform.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: terraform.write
+
+resources:
+  schemas:
+    - id: terraform/TerraformActionInput
+      path: schemas/TerraformActionInput.json
+    - id: terraform/TerraformActionResult
+      path: schemas/TerraformActionResult.json
+  workflows:
+    - id: terraform.read
+      path: workflows/terraform_read.yaml
+    - id: terraform.write
+      path: workflows/terraform_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.terraform.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.terraform.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/terraform/pack/schemas/TerraformActionInput.json
+++ b/packs/terraform/pack/schemas/TerraformActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Terraform Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. plan.run, drift.detect, apply.run."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/terraform/pack/schemas/TerraformActionResult.json
+++ b/packs/terraform/pack/schemas/TerraformActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Terraform Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/terraform/pack/workflows/terraform_read.yaml
+++ b/packs/terraform/pack/workflows/terraform_read.yaml
@@ -1,0 +1,23 @@
+id: terraform.read
+name: Terraform Read
+description: Generate Terraform plans or drift reports.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Terraform Read action
+    type: worker
+    topic: job.terraform.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: terraform/TerraformActionInput
+    output_schema_id: terraform/TerraformActionResult
+    meta:
+      pack_id: terraform
+      capability: terraform.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/terraform/pack/workflows/terraform_write.yaml
+++ b/packs/terraform/pack/workflows/terraform_write.yaml
@@ -1,0 +1,23 @@
+id: terraform.write
+name: Terraform Write
+description: Apply Terraform changes with approvals.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Terraform Write action
+    type: worker
+    topic: job.terraform.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: terraform/TerraformActionInput
+    output_schema_id: terraform/TerraformActionResult
+    meta:
+      pack_id: terraform
+      capability: terraform.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/vault/pack/overlays/policy.fragment.yaml
+++ b/packs/vault/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,10 @@
+version: v1
+rules:
+  - id: vault-secrets
+    match:
+      topics:
+        - job.vault.read
+      risk_tags:
+        - secrets
+    decision: require_approval
+    reason: "Vault secret access requires approval"

--- a/packs/vault/pack/overlays/pools.patch.yaml
+++ b/packs/vault/pack/overlays/pools.patch.yaml
@@ -1,0 +1,5 @@
+topics:
+  job.vault.read: vault
+pools:
+  vault:
+    requires: ["network:egress"]

--- a/packs/vault/pack/overlays/timeouts.patch.yaml
+++ b/packs/vault/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,4 @@
+topics:
+  job.vault.read:
+    timeout_seconds: 60
+    max_retries: 2

--- a/packs/vault/pack/pack.yaml
+++ b/packs/vault/pack/pack.yaml
@@ -1,0 +1,54 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: vault
+  version: 0.1.0
+  title: Vault
+  description: Vault secret resolution and dynamic credentials.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.vault.read
+    requires: ["network:egress"]
+    riskTags: ["secrets", "network"]
+    capability: vault.read
+
+resources:
+  schemas:
+    - id: vault/VaultActionInput
+      path: schemas/VaultActionInput.json
+    - id: vault/VaultActionResult
+      path: schemas/VaultActionResult.json
+  workflows:
+    - id: vault.read
+      path: workflows/vault_read.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: secrets_require_approval
+      request:
+        tenantId: default
+        topic: job.vault.read
+        riskTags: ["secrets", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/vault/pack/schemas/VaultActionInput.json
+++ b/packs/vault/pack/schemas/VaultActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Vault Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. secrets.read, auth.token.lookup, credentials.generate."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/vault/pack/schemas/VaultActionResult.json
+++ b/packs/vault/pack/schemas/VaultActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Vault Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/vault/pack/workflows/vault_read.yaml
+++ b/packs/vault/pack/workflows/vault_read.yaml
@@ -1,0 +1,23 @@
+id: vault.read
+name: Vault Read
+description: Resolve secrets or dynamic credentials via Vault.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Vault Read action
+    type: worker
+    topic: job.vault.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: vault/VaultActionInput
+    output_schema_id: vault/VaultActionResult
+    meta:
+      pack_id: vault
+      capability: vault.read
+      risk_tags: ["secrets", "network"]
+      requires: ["network:egress"]


### PR DESCRIPTION
## Summary
- add pack bundles for aws/azure/cron-triggers/datadog/gcp/gitlab/msteams/opentelemetry/pagerduty/prometheus-query/sentry/servicenow/terraform/vault
- mark roadmap pack statuses as in-repo

## Testing
- python3 tools/pack_audit.py (run from `feat/pack-audit` branch)
