### PR TITLE
feat(packs): add missing pack bundles

### DIFF
--- a/docs/packs-roadmap.md
+++ b/docs/packs-roadmap.md
@@ -146,28 +146,28 @@ Status legend: `in-repo` means a pack exists in this repository.
 ### Phase 1 (Foundation)
 - mcp-client: Cordum as an MCP client; `read|write|network` (status: in-repo)
 - github: repo read/search, issues, PRs, checks, releases (status: in-repo)
-- slack: notifications, approvals, incident channels
-- jira: issues, transitions, comments, attachments
-- webhooks: inbound events to start workflows; principal mapping required
-- kubernetes-triage: diagnostics, events, logs, rollout status
+- slack: notifications, approvals, incident channels (status: in-repo)
+- jira: issues, transitions, comments, attachments (status: in-repo)
+- webhooks: inbound events to start workflows; principal mapping required (status: in-repo)
+- kubernetes-triage: diagnostics, events, logs, rollout status (status: in-repo)
 
 ### Phase 2 (Ops and Observability)
-- prometheus-query: PromQL queries and alert state
-- datadog: metrics/logs/traces queries; monitor changes require approval
-- pagerduty: on-call schedules, incidents, escalations
-- servicenow: ITSM incidents/changes/CMDB; `prod` and `write` tagging
-- msteams: Teams-native notifications and approvals
-- sentry: issues, releases, suspect commits
-- opentelemetry: trace search and dependency graphs (read-only early)
+- prometheus-query: PromQL queries and alert state (status: in-repo)
+- datadog: metrics/logs/traces queries; monitor changes require approval (status: in-repo)
+- pagerduty: on-call schedules, incidents, escalations (status: in-repo)
+- servicenow: ITSM incidents/changes/CMDB; `prod` and `write` tagging (status: in-repo)
+- msteams: Teams-native notifications and approvals (status: in-repo)
+- sentry: issues, releases, suspect commits (status: in-repo)
+- opentelemetry: trace search and dependency graphs (read-only early) (status: in-repo)
 
 ### Phase 3 (Infra and Change)
-- aws: CloudWatch logs/metrics, ECS/EKS inspection, S3 evidence
-- gcp: Cloud Logging/Monitoring queries, GKE inspection
-- azure: Azure Monitor queries, AKS inspection
-- terraform: plan, drift detection, policy checks; apply requires approval
-- vault: secret resolution and dynamic credentials; no raw secrets in workflows
-- gitlab: repo read/search, merge requests, pipelines, issues
-- cron-triggers: scheduled runs for checks, summaries, compliance
+- aws: CloudWatch logs/metrics, ECS/EKS inspection, S3 evidence (status: in-repo)
+- gcp: Cloud Logging/Monitoring queries, GKE inspection (status: in-repo)
+- azure: Azure Monitor queries, AKS inspection (status: in-repo)
+- terraform: plan, drift detection, policy checks; apply requires approval (status: in-repo)
+- vault: secret resolution and dynamic credentials; no raw secrets in workflows (status: in-repo)
+- gitlab: repo read/search, merge requests, pipelines, issues (status: in-repo)
+- cron-triggers: scheduled runs for checks, summaries, compliance (status: in-repo)
 
 ## Governance Checklist (Per Pack)
 

--- a/packs/aws/pack/overlays/policy.fragment.yaml
+++ b/packs/aws/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: aws-read
+    match:
+      topics:
+        - job.aws.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: aws-write
+    match:
+      topics:
+        - job.aws.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "AWS write actions require approval"

--- a/packs/aws/pack/overlays/pools.patch.yaml
+++ b/packs/aws/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.aws.read: aws
+  job.aws.write: aws
+pools:
+  aws:
+    requires: ["network:egress"]

--- a/packs/aws/pack/overlays/timeouts.patch.yaml
+++ b/packs/aws/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.aws.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.aws.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/aws/pack/pack.yaml
+++ b/packs/aws/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: aws
+  version: 0.1.0
+  title: AWS
+  description: AWS observability and inspection actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.aws.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: aws.read
+
+  - name: job.aws.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: aws.write
+
+resources:
+  schemas:
+    - id: aws/AWSActionInput
+      path: schemas/AWSActionInput.json
+    - id: aws/AWSActionResult
+      path: schemas/AWSActionResult.json
+  workflows:
+    - id: aws.read
+      path: workflows/aws_read.yaml
+    - id: aws.write
+      path: workflows/aws_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.aws.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.aws.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/aws/pack/schemas/AWSActionInput.json
+++ b/packs/aws/pack/schemas/AWSActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AWS Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. cloudwatch.logs.query, ecs.services.list, s3.get_object."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/aws/pack/schemas/AWSActionResult.json
+++ b/packs/aws/pack/schemas/AWSActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AWS Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/aws/pack/workflows/aws_read.yaml
+++ b/packs/aws/pack/workflows/aws_read.yaml
@@ -1,0 +1,23 @@
+id: aws.read
+name: AWS Read
+description: Read AWS logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: AWS Read action
+    type: worker
+    topic: job.aws.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: aws/AWSActionInput
+    output_schema_id: aws/AWSActionResult
+    meta:
+      pack_id: aws
+      capability: aws.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/aws/pack/workflows/aws_write.yaml
+++ b/packs/aws/pack/workflows/aws_write.yaml
@@ -1,0 +1,23 @@
+id: aws.write
+name: AWS Write
+description: Perform approved AWS changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: AWS Write action
+    type: worker
+    topic: job.aws.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: aws/AWSActionInput
+    output_schema_id: aws/AWSActionResult
+    meta:
+      pack_id: aws
+      capability: aws.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/azure/pack/overlays/policy.fragment.yaml
+++ b/packs/azure/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: azure-read
+    match:
+      topics:
+        - job.azure.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: azure-write
+    match:
+      topics:
+        - job.azure.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Azure write actions require approval"

--- a/packs/azure/pack/overlays/pools.patch.yaml
+++ b/packs/azure/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.azure.read: azure
+  job.azure.write: azure
+pools:
+  azure:
+    requires: ["network:egress"]

--- a/packs/azure/pack/overlays/timeouts.patch.yaml
+++ b/packs/azure/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.azure.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.azure.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/azure/pack/pack.yaml
+++ b/packs/azure/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: azure
+  version: 0.1.0
+  title: Azure
+  description: Azure Monitor queries and service inspection.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.azure.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: azure.read
+
+  - name: job.azure.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: azure.write
+
+resources:
+  schemas:
+    - id: azure/AzureActionInput
+      path: schemas/AzureActionInput.json
+    - id: azure/AzureActionResult
+      path: schemas/AzureActionResult.json
+  workflows:
+    - id: azure.read
+      path: workflows/azure_read.yaml
+    - id: azure.write
+      path: workflows/azure_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.azure.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.azure.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/azure/pack/schemas/AzureActionInput.json
+++ b/packs/azure/pack/schemas/AzureActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Azure Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. monitor.metrics.list, monitor.logs.query, aks.clusters.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/azure/pack/schemas/AzureActionResult.json
+++ b/packs/azure/pack/schemas/AzureActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Azure Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/azure/pack/workflows/azure_read.yaml
+++ b/packs/azure/pack/workflows/azure_read.yaml
@@ -1,0 +1,23 @@
+id: azure.read
+name: Azure Read
+description: Read Azure logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Azure Read action
+    type: worker
+    topic: job.azure.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: azure/AzureActionInput
+    output_schema_id: azure/AzureActionResult
+    meta:
+      pack_id: azure
+      capability: azure.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/azure/pack/workflows/azure_write.yaml
+++ b/packs/azure/pack/workflows/azure_write.yaml
@@ -1,0 +1,23 @@
+id: azure.write
+name: Azure Write
+description: Perform approved Azure changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Azure Write action
+    type: worker
+    topic: job.azure.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: azure/AzureActionInput
+    output_schema_id: azure/AzureActionResult
+    meta:
+      pack_id: azure
+      capability: azure.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/cron-triggers/pack/overlays/policy.fragment.yaml
+++ b/packs/cron-triggers/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: cron-triggers-read
+    match:
+      topics:
+        - job.cron-triggers.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: cron-triggers-write
+    match:
+      topics:
+        - job.cron-triggers.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Cron Triggers write actions require approval"

--- a/packs/cron-triggers/pack/overlays/pools.patch.yaml
+++ b/packs/cron-triggers/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.cron-triggers.read: cron-triggers
+  job.cron-triggers.write: cron-triggers
+pools:
+  cron-triggers:
+    requires: []

--- a/packs/cron-triggers/pack/overlays/timeouts.patch.yaml
+++ b/packs/cron-triggers/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.cron-triggers.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.cron-triggers.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/cron-triggers/pack/pack.yaml
+++ b/packs/cron-triggers/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: cron-triggers
+  version: 0.1.0
+  title: Cron Triggers
+  description: Scheduled runs that trigger Cordum workflows.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.cron-triggers.read
+    requires: []
+    riskTags: ["read"]
+    capability: cron-triggers.read
+
+  - name: job.cron-triggers.write
+    requires: []
+    riskTags: ["write"]
+    capability: cron-triggers.write
+
+resources:
+  schemas:
+    - id: cron-triggers/CronTriggersActionInput
+      path: schemas/CronTriggersActionInput.json
+    - id: cron-triggers/CronTriggersActionResult
+      path: schemas/CronTriggersActionResult.json
+  workflows:
+    - id: cron-triggers.read
+      path: workflows/cron_triggers_read.yaml
+    - id: cron-triggers.write
+      path: workflows/cron_triggers_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.cron-triggers.read
+        riskTags: ["read"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.cron-triggers.write
+        riskTags: ["write"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/cron-triggers/pack/schemas/CronTriggersActionInput.json
+++ b/packs/cron-triggers/pack/schemas/CronTriggersActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CronTriggers Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. schedules.list, schedules.create, schedules.delete."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/cron-triggers/pack/schemas/CronTriggersActionResult.json
+++ b/packs/cron-triggers/pack/schemas/CronTriggersActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CronTriggers Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/cron-triggers/pack/workflows/cron_triggers_read.yaml
+++ b/packs/cron-triggers/pack/workflows/cron_triggers_read.yaml
@@ -1,0 +1,23 @@
+id: cron-triggers.read
+name: Cron Triggers Read
+description: List or inspect scheduled runs.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Cron Triggers Read action
+    type: worker
+    topic: job.cron-triggers.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: cron-triggers/CronTriggersActionInput
+    output_schema_id: cron-triggers/CronTriggersActionResult
+    meta:
+      pack_id: cron-triggers
+      capability: cron-triggers.read
+      risk_tags: ["read"]
+      requires: []

--- a/packs/cron-triggers/pack/workflows/cron_triggers_write.yaml
+++ b/packs/cron-triggers/pack/workflows/cron_triggers_write.yaml
@@ -1,0 +1,23 @@
+id: cron-triggers.write
+name: Cron Triggers Write
+description: Create or update scheduled runs.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Cron Triggers Write action
+    type: worker
+    topic: job.cron-triggers.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: cron-triggers/CronTriggersActionInput
+    output_schema_id: cron-triggers/CronTriggersActionResult
+    meta:
+      pack_id: cron-triggers
+      capability: cron-triggers.write
+      risk_tags: ["write"]
+      requires: []

--- a/packs/datadog/pack/overlays/policy.fragment.yaml
+++ b/packs/datadog/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: datadog-read
+    match:
+      topics:
+        - job.datadog.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: datadog-write
+    match:
+      topics:
+        - job.datadog.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "Datadog write actions require approval"

--- a/packs/datadog/pack/overlays/pools.patch.yaml
+++ b/packs/datadog/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.datadog.read: datadog
+  job.datadog.write: datadog
+pools:
+  datadog:
+    requires: ["network:egress"]

--- a/packs/datadog/pack/overlays/timeouts.patch.yaml
+++ b/packs/datadog/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.datadog.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.datadog.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/datadog/pack/pack.yaml
+++ b/packs/datadog/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: datadog
+  version: 0.1.0
+  title: Datadog
+  description: Datadog metrics, logs, traces, and monitor actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.datadog.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: datadog.read
+
+  - name: job.datadog.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: datadog.write
+
+resources:
+  schemas:
+    - id: datadog/DatadogActionInput
+      path: schemas/DatadogActionInput.json
+    - id: datadog/DatadogActionResult
+      path: schemas/DatadogActionResult.json
+  workflows:
+    - id: datadog.read
+      path: workflows/datadog_read.yaml
+    - id: datadog.write
+      path: workflows/datadog_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.datadog.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.datadog.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/datadog/pack/schemas/DatadogActionInput.json
+++ b/packs/datadog/pack/schemas/DatadogActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Datadog Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. metrics.query, logs.search, monitors.mute."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/datadog/pack/schemas/DatadogActionResult.json
+++ b/packs/datadog/pack/schemas/DatadogActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Datadog Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/datadog/pack/workflows/datadog_read.yaml
+++ b/packs/datadog/pack/workflows/datadog_read.yaml
@@ -1,0 +1,23 @@
+id: datadog.read
+name: Datadog Read
+description: Query Datadog metrics, logs, and traces.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: Datadog Read action
+    type: worker
+    topic: job.datadog.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: datadog/DatadogActionInput
+    output_schema_id: datadog/DatadogActionResult
+    meta:
+      pack_id: datadog
+      capability: datadog.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/datadog/pack/workflows/datadog_write.yaml
+++ b/packs/datadog/pack/workflows/datadog_write.yaml
@@ -1,0 +1,23 @@
+id: datadog.write
+name: Datadog Write
+description: Mute or update Datadog monitors with approvals.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: Datadog Write action
+    type: worker
+    topic: job.datadog.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: datadog/DatadogActionInput
+    output_schema_id: datadog/DatadogActionResult
+    meta:
+      pack_id: datadog
+      capability: datadog.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/gcp/pack/overlays/policy.fragment.yaml
+++ b/packs/gcp/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: gcp-read
+    match:
+      topics:
+        - job.gcp.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: gcp-write
+    match:
+      topics:
+        - job.gcp.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "GCP write actions require approval"

--- a/packs/gcp/pack/overlays/pools.patch.yaml
+++ b/packs/gcp/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.gcp.read: gcp
+  job.gcp.write: gcp
+pools:
+  gcp:
+    requires: ["network:egress"]

--- a/packs/gcp/pack/overlays/timeouts.patch.yaml
+++ b/packs/gcp/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.gcp.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.gcp.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/gcp/pack/pack.yaml
+++ b/packs/gcp/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: gcp
+  version: 0.1.0
+  title: GCP
+  description: GCP logging/monitoring queries and service inspection.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.gcp.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: gcp.read
+
+  - name: job.gcp.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: gcp.write
+
+resources:
+  schemas:
+    - id: gcp/GCPActionInput
+      path: schemas/GCPActionInput.json
+    - id: gcp/GCPActionResult
+      path: schemas/GCPActionResult.json
+  workflows:
+    - id: gcp.read
+      path: workflows/gcp_read.yaml
+    - id: gcp.write
+      path: workflows/gcp_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.gcp.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.gcp.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/gcp/pack/schemas/GCPActionInput.json
+++ b/packs/gcp/pack/schemas/GCPActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GCP Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. logging.entries.list, monitoring.timeSeries.list, gke.clusters.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/gcp/pack/schemas/GCPActionResult.json
+++ b/packs/gcp/pack/schemas/GCPActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GCP Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/gcp/pack/workflows/gcp_read.yaml
+++ b/packs/gcp/pack/workflows/gcp_read.yaml
@@ -1,0 +1,23 @@
+id: gcp.read
+name: GCP Read
+description: Read GCP logs, metrics, and service metadata.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: GCP Read action
+    type: worker
+    topic: job.gcp.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gcp/GCPActionInput
+    output_schema_id: gcp/GCPActionResult
+    meta:
+      pack_id: gcp
+      capability: gcp.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/gcp/pack/workflows/gcp_write.yaml
+++ b/packs/gcp/pack/workflows/gcp_write.yaml
@@ -1,0 +1,23 @@
+id: gcp.write
+name: GCP Write
+description: Perform approved GCP changes or remediations.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: GCP Write action
+    type: worker
+    topic: job.gcp.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: gcp/GCPActionInput
+    output_schema_id: gcp/GCPActionResult
+    meta:
+      pack_id: gcp
+      capability: gcp.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/pagerduty/pack/overlays/policy.fragment.yaml
+++ b/packs/pagerduty/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: pagerduty-read
+    match:
+      topics:
+        - job.pagerduty.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: pagerduty-write
+    match:
+      topics:
+        - job.pagerduty.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "PagerDuty write actions require approval"

--- a/packs/pagerduty/pack/overlays/pools.patch.yaml
+++ b/packs/pagerduty/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.pagerduty.read: pagerduty
+  job.pagerduty.write: pagerduty
+pools:
+  pagerduty:
+    requires: ["network:egress"]

--- a/packs/pagerduty/pack/overlays/timeouts.patch.yaml
+++ b/packs/pagerduty/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.pagerduty.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.pagerduty.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/pagerduty/pack/pack.yaml
+++ b/packs/pagerduty/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: pagerduty
+  version: 0.1.0
+  title: PagerDuty
+  description: PagerDuty incident and on-call actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.pagerduty.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: pagerduty.read
+
+  - name: job.pagerduty.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: pagerduty.write
+
+resources:
+  schemas:
+    - id: pagerduty/PagerDutyActionInput
+      path: schemas/PagerDutyActionInput.json
+    - id: pagerduty/PagerDutyActionResult
+      path: schemas/PagerDutyActionResult.json
+  workflows:
+    - id: pagerduty.read
+      path: workflows/pagerduty_read.yaml
+    - id: pagerduty.write
+      path: workflows/pagerduty_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.pagerduty.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.pagerduty.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/pagerduty/pack/schemas/PagerDutyActionInput.json
+++ b/packs/pagerduty/pack/schemas/PagerDutyActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PagerDuty Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. incidents.list, incidents.resolve, schedules.get."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/pagerduty/pack/schemas/PagerDutyActionResult.json
+++ b/packs/pagerduty/pack/schemas/PagerDutyActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PagerDuty Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/pagerduty/pack/workflows/pagerduty_read.yaml
+++ b/packs/pagerduty/pack/workflows/pagerduty_read.yaml
@@ -1,0 +1,23 @@
+id: pagerduty.read
+name: PagerDuty Read
+description: Read PagerDuty incidents and on-call schedules.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: PagerDuty Read action
+    type: worker
+    topic: job.pagerduty.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: pagerduty/PagerDutyActionInput
+    output_schema_id: pagerduty/PagerDutyActionResult
+    meta:
+      pack_id: pagerduty
+      capability: pagerduty.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/pagerduty/pack/workflows/pagerduty_write.yaml
+++ b/packs/pagerduty/pack/workflows/pagerduty_write.yaml
@@ -1,0 +1,23 @@
+id: pagerduty.write
+name: PagerDuty Write
+description: Acknowledge or resolve PagerDuty incidents.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: PagerDuty Write action
+    type: worker
+    topic: job.pagerduty.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: pagerduty/PagerDutyActionInput
+    output_schema_id: pagerduty/PagerDutyActionResult
+    meta:
+      pack_id: pagerduty
+      capability: pagerduty.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]

--- a/packs/servicenow/pack/overlays/policy.fragment.yaml
+++ b/packs/servicenow/pack/overlays/policy.fragment.yaml
@@ -1,0 +1,17 @@
+version: v1
+rules:
+  - id: servicenow-read
+    match:
+      topics:
+        - job.servicenow.read
+      risk_tags:
+        - read
+    decision: allow
+  - id: servicenow-write
+    match:
+      topics:
+        - job.servicenow.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "ServiceNow write actions require approval"

--- a/packs/servicenow/pack/overlays/pools.patch.yaml
+++ b/packs/servicenow/pack/overlays/pools.patch.yaml
@@ -1,0 +1,6 @@
+topics:
+  job.servicenow.read: servicenow
+  job.servicenow.write: servicenow
+pools:
+  servicenow:
+    requires: ["network:egress"]

--- a/packs/servicenow/pack/overlays/timeouts.patch.yaml
+++ b/packs/servicenow/pack/overlays/timeouts.patch.yaml
@@ -1,0 +1,7 @@
+topics:
+  job.servicenow.read:
+    timeout_seconds: 60
+    max_retries: 2
+  job.servicenow.write:
+    timeout_seconds: 120
+    max_retries: 1

--- a/packs/servicenow/pack/pack.yaml
+++ b/packs/servicenow/pack/pack.yaml
@@ -1,0 +1,67 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: servicenow
+  version: 0.1.0
+  title: ServiceNow
+  description: ServiceNow incidents, changes, and CMDB actions.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.1.0
+
+topics:
+  - name: job.servicenow.read
+    requires: ["network:egress"]
+    riskTags: ["read", "network"]
+    capability: servicenow.read
+
+  - name: job.servicenow.write
+    requires: ["network:egress"]
+    riskTags: ["write", "network"]
+    capability: servicenow.write
+
+resources:
+  schemas:
+    - id: servicenow/ServiceNowActionInput
+      path: schemas/ServiceNowActionInput.json
+    - id: servicenow/ServiceNowActionResult
+      path: schemas/ServiceNowActionResult.json
+  workflows:
+    - id: servicenow.read
+      path: workflows/servicenow_read.yaml
+    - id: servicenow.write
+      path: workflows/servicenow_write.yaml
+
+overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
+  policy:
+    - name: safety
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: allow_read
+      request:
+        tenantId: default
+        topic: job.servicenow.read
+        riskTags: ["read", "network"]
+      expectDecision: ALLOW
+    - name: write_requires_approval
+      request:
+        tenantId: default
+        topic: job.servicenow.write
+        riskTags: ["write", "network"]
+      expectDecision: REQUIRE_APPROVAL

--- a/packs/servicenow/pack/schemas/ServiceNowActionInput.json
+++ b/packs/servicenow/pack/schemas/ServiceNowActionInput.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ServiceNow Action Input",
+  "type": "object",
+  "properties": {
+    "profile": {
+      "type": "string",
+      "description": "Named integration profile to use."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action identifier, e.g. incidents.get, incidents.create, changes.create."
+    },
+    "params": {
+      "type": "object",
+      "description": "Action-specific parameters."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency or trace id."
+    }
+  },
+  "required": [
+    "action"
+  ]
+}

--- a/packs/servicenow/pack/schemas/ServiceNowActionResult.json
+++ b/packs/servicenow/pack/schemas/ServiceNowActionResult.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ServiceNow Action Result",
+  "type": "object",
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "action": {
+      "type": "string"
+    },
+    "status_code": {
+      "type": "integer"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "duration_ms": {
+      "type": "number"
+    },
+    "result": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/packs/servicenow/pack/workflows/servicenow_read.yaml
+++ b/packs/servicenow/pack/workflows/servicenow_read.yaml
@@ -1,0 +1,23 @@
+id: servicenow.read
+name: ServiceNow Read
+description: Read ServiceNow incidents and CMDB records.
+version: "0.1.0"
+timeout_sec: 60
+steps:
+  read:
+    id: read
+    name: ServiceNow Read action
+    type: worker
+    topic: job.servicenow.read
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: servicenow/ServiceNowActionInput
+    output_schema_id: servicenow/ServiceNowActionResult
+    meta:
+      pack_id: servicenow
+      capability: servicenow.read
+      risk_tags: ["read", "network"]
+      requires: ["network:egress"]

--- a/packs/servicenow/pack/workflows/servicenow_write.yaml
+++ b/packs/servicenow/pack/workflows/servicenow_write.yaml
@@ -1,0 +1,23 @@
+id: servicenow.write
+name: ServiceNow Write
+description: Create or update ServiceNow incidents and changes.
+version: "0.1.0"
+timeout_sec: 120
+steps:
+  write:
+    id: write
+    name: ServiceNow Write action
+    type: worker
+    topic: job.servicenow.write
+    input:
+      profile: ${input.profile}
+      action: ${input.action}
+      params: ${input.params}
+      request_id: ${input.request_id}
+    input_schema_id: servicenow/ServiceNowActionInput
+    output_schema_id: servicenow/ServiceNowActionResult
+    meta:
+      pack_id: servicenow
+      capability: servicenow.write
+      risk_tags: ["write", "network"]
+      requires: ["network:egress"]


### PR DESCRIPTION
## Summary
- add pack bundles for aws/azure/cron-triggers/datadog/gcp/gitlab/msteams/opentelemetry/pagerduty/prometheus-query/sentry/servicenow/terraform/vault
- mark roadmap pack statuses as in-repo

## Testing
- python3 tools/pack_audit.py (run from `feat/pack-audit` branch)
