### PR TITLE
fix(webhooks): fallback to inline secret

### DIFF
--- a/packs/webhooks/internal/server/server.go
+++ b/packs/webhooks/internal/server/server.go
@@ -242,8 +242,11 @@ func headersToMap(headers http.Header) map[string][]string {
 }
 
 func resolveSecret(value, envKey string) string {
-	if strings.TrimSpace(envKey) != "" {
-		return strings.TrimSpace(os.Getenv(envKey))
+	envKey = strings.TrimSpace(envKey)
+	if envKey != "" {
+		if envValue := strings.TrimSpace(os.Getenv(envKey)); envValue != "" {
+			return envValue
+		}
 	}
 	return strings.TrimSpace(value)
 }


### PR DESCRIPTION
## Summary
- fall back to inline secret when SecretEnv is set but env var is missing

## Testing
- not run locally (module uses CI-provided replace deps)

## Issues
Closes #67

## Public
public/ not regenerated (no changes)
