### PR TITLE
feat(monday): Monday.com integration pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,114 +1,131 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with the cordum-packs repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 
-28 integration packs for the Cordum platform. Each pack is an independent Go module with its own worker binary, manifest, schemas, and workflows. Packs connect Cordum to external services (Slack, GitHub, AWS, Jira, etc.).
+The official catalog of Cordum packs. A pack is a versioned bundle (workflows, JSON schemas, policy/config overlays) plus optional Go runtime code (worker/bridge/receiver). Packs are CAP-native workers that communicate via `BusPacket` envelopes over NATS with policy-before-dispatch gating.
 
-- **No root go.mod** — each pack has its own module
-- **SDK module:** `github.com/cordum/cordum/sdk` (in `sdk/` directory)
-- **SDK depends on:** CAP v2.0.19, NATS, gRPC, Protobuf
+There are **25 packs** under `packs/`. Of these, 21 ship Go runtime code (a `go.mod` + `cmd/`); 4 are **bundle-only** (`aws`, `azure`, `gcp`, `langchain-guard` — just a `pack/` directory, no Go module).
+
+- **No root `go.mod`** — each Go pack is an independent module (the root `go.sum` is empty/vestigial).
+- **Pack module path:** `github.com/cordum-io/cordum-packs/packs/<name>`
+- **Shared SDK module:** `github.com/cordum/cordum/sdk` (in `sdk/`), consumed via a local `replace github.com/cordum/cordum/sdk => ../../sdk` directive in each pack's `go.mod` (version pinned `v0.2.0`).
+- **Go:** 1.25.9. **CAP:** `github.com/cordum-io/cap/v2 v2.11.0`. Deps: NATS, redis/go-redis, gRPC, Protobuf.
 
 ## Common Commands
 
-### SDK (shared library)
+### A single Go pack (most work happens here)
+```bash
+cd packs/<pack-name>
+go build ./...
+go test ./...                                  # includes manifest + schema validation tests
+go test ./internal/worker/ -run TestPackManifest
+go build -o cordum-<pack>.exe ./cmd/cordum-<pack>/
+```
+
+### SDK
 ```bash
 cd sdk && go build ./... && go test ./...
 ```
 
-### Individual Pack
+### Build the catalog + bundles
 ```bash
-cd packs/<pack-name>
-go build ./...
-go test ./...
-go build -o cordum-<pack>.exe ./cmd/cordum-<pack>/
+python -m venv .venv; . .venv/Scripts/activate     # PowerShell: .venv\Scripts\Activate.ps1
+pip install -r tools/requirements.txt
+python tools/build.py            # writes public/catalog.json + public/packs/<id>/<version>/pack.tgz
+python tools/build.py --clean    # wipe public/ first
+python tools/pack_audit.py       # check every bundle has required assets
+python tools/pack_scaffold.py my-pack --title "My Pack" --description "..."
 ```
 
-### Catalog Build
-```bash
-python tools/build.py    # Generates public/catalog.json + bundled packs
-```
-
-## Pack Structure (convention)
+## Pack Structure
 
 ```
 packs/<pack-name>/
-├── pack/
-│   ├── pack.yaml           # Manifest: topics, schemas, workflows, overlays
-│   ├── schemas/             # JSON schemas for inputs/outputs
-│   ├── workflows/           # YAML workflow definitions
-│   └── overlays/            # Policy fragments
-├── cmd/cordum-<pack>/       # Runtime worker binary entrypoint
-├── go.mod / go.sum
-├── deploy/env.example       # Required environment variables
+├── pack/                       # the installable bundle (build.py also accepts pack.yaml at pack root)
+│   ├── pack.yaml               # manifest (see below)
+│   ├── schemas/                # JSON Schemas for topic input/output
+│   ├── workflows/              # YAML workflow definitions
+│   └── overlays/               # policy fragment + config json_merge_patch overlays
+├── cmd/cordum-<pack>/main.go   # worker binary entrypoint (Go packs only)
+├── internal/                   # config, gateway client, service client, worker (Go packs only)
+├── go.mod / go.sum             # Go packs only
+├── deploy/env.example          # required env vars / credentials
 └── README.md
 ```
 
-### pack.yaml Manifest
+### pack.yaml manifest
 
-The `pack.yaml` defines what topics the pack handles, input/output schemas, bundled workflows, and policy overlays.
+```yaml
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+metadata:        { id, version, title, description, image }
+compatibility:   { protocolVersion, minCoreVersion }
+topics:                                    # each job topic the pack handles
+  - name: job.<pack>.<verb>                # e.g. job.slack.write
+    requires: ["network:egress"]           # capability requirements
+    riskTags: ["write", "network"]         # drive policy decisions (read vs write)
+    capability: <pack>.<verb>
+    inputSchema:  <id>                      # references resources.schemas[].id
+    outputSchema: <id>
+resources:
+  schemas:   [ { id, path } ]               # path relative to bundle root (schemas/*.json)
+  workflows: [ { id, path } ]               # workflows/*.yaml
+overlays:
+  config: [ { name, scope, key, strategy: json_merge_patch, path } ]
+  policy: [ { name, strategy: bundle_fragment, path } ]
+tests:
+  policySimulations:                        # exercised by go test (manifest_test.go) and pack publish
+    - { name, request: {tenantId, topic, riskTags}, expectDecision: ALLOW|REQUIRE_APPROVAL|DENY }
+```
 
-#### Topic Registry integration (added 2026-04)
+Job topics follow `job.<pack>.<verb>`; `riskTags` (e.g. `read` vs `write`) drive whether the control plane allows the job or requires approval. The `manifest_test.go`/schema tests in `internal/worker/` validate that `pack.yaml` parses and that the worker's accepted/emitted payloads match the JSON schemas under `pack/schemas/` — keep them in sync.
 
-`pack install` now registers each declared topic in the cordum control-plane Topic Registry (`/api/v1/topics`); `pack uninstall` removes them. Pack manifest declarations include:
+`cordumctl pack install` registers only the bundle assets; to actually execute a topic you must run that pack's worker binary. Workflows can compose multiple packs, so every job topic a workflow uses needs a running worker. `cordumctl pack verify-signature <pack> ...` checks bundle signing (see `packs/hello-pack/README.md`).
 
-- `inputSchema` / `outputSchema` — JSON Schema draft-07 references that the gateway validates at job-submit time when `SCHEMA_ENFORCEMENT=warn|enforce` is set on the cordum side.
-- `pool` — target worker pool (must exist or be auto-provisioned).
-- `pack_id` — back-reference to the owning pack.
+### Running a worker against a stack
 
-Manifests must keep the schema files under `pack/schemas/` consistent with what the worker actually accepts and emits — submit-time schema enforcement on the cordum side will reject jobs whose payloads don't match the registered shape.
+Workers are configured entirely via env (see each pack's `deploy/env.example`). Connection vars are shared across all Go packs and default to a local stack, so a worker runs with no config against `docker compose`:
 
-`cordumctl pack verify <pack_id>` runs policy simulation tests against the registered topics and pack policies before publish.
+- `CORDUM_GATEWAY_URL` (default `http://localhost:8081`), `CORDUM_API_KEY`, `CORDUM_TENANT_ID` (default `default`)
+- `CORDUM_NATS_URL` (default `nats://localhost:4222`) — bus transport, `CORDUM_REDIS_URL` (default `redis://localhost:6379`) — result TTL store
 
-### Cordum platform context (recent)
-
-For website / marketing copy or for generated docs, note:
-
-- `cordum-enterprise` repo retired 2026-04-23. Enterprise features (SAML/OIDC SSO, SCIM, advanced RBAC, SIEM export, legal hold) are now in core `cordum` behind license entitlements. Packs do not need to be re-licensed per environment; they remain BUSL-1.1.
-- CAP protocol v2.9.0: `Agent.Start()` auto-publishes `Handshake{ready_topics, auth_token}`. SDK consumers don't need to call `publishHandshake()` manually anymore.
-
-## 28 Packs by Category
-
-| Category | Packs |
-|----------|-------|
-| Cloud | aws, azure, gcp |
-| Monitoring | datadog, opentelemetry, prometheus-query, sentry |
-| Communication | slack, msteams, pagerduty |
-| VCS/CI | github, gitlab, terraform |
-| Ticketing | jira, servicenow |
-| Infrastructure | kubernetes-triage, vault |
-| Bridge | mcp-bridge, mcp-client, webhooks |
-| Standard | pic-standard, hello-pack (reference), cap, cordum |
-| Automation | cron-triggers, incident-enricher |
+Per-pack settings use the `CORDUM_<PACK>_*` prefix (e.g. `CORDUM_SLACK_SUBJECTS=job.slack.*`, `..._MAX_PARALLEL`, `..._REQUEST_TIMEOUT`, `..._TOKEN` / `..._TOKEN_ENV`, `..._PROFILES`, allow/deny lists). Run with `go run ./cmd/cordum-<pack>` (binary handles SIGINT/SIGTERM). Runtime details: `docs/pack-runtime-guide.md`.
 
 ## SDK (`sdk/`)
 
-Shared library used by all packs:
-- `client/` — Cordum API client
-- `gen/` — gRPC generated stubs
+Shared library imported by all Go packs:
+- `client/` — Cordum/gateway API client
+- `gen/` — generated gRPC/protobuf stubs
 - `runtime/` — worker pool, bus helpers, TTL store
+- `logging/` — structured logging helpers
 
 ## Agent Adapters (`integrations/agent-adapters/`)
 
-Python package with adapters for: CrewAI, LangChain, OpenAI Tools, MCP Client, plus autogen.py.
+Python package (PyPI distribution name `cordum-adapters`, import `cordum_agent_adapters`) exposing MCP tools to agent frameworks. Each adapter expects an MCP stdio server such as `packs/mcp-bridge`. Public exports: `build_langchain_tools`, `build_crewai_tools`, `build_autogen_tools`, `build_autogen_openai_tools`, `mcp_tools_to_openai_tools` / `mcp_tool_to_openai_tool`, the `McpStdioClient`, and the `Adapter*Error` hierarchy. Tests under `integrations/agent-adapters/tests/`.
+
+## Packs by Category
+
+| Category | Packs |
+|----------|-------|
+| Cloud (bundle-only) | aws, azure, gcp |
+| Monitoring | datadog, opentelemetry, prometheus-query, sentry |
+| Communication | slack, msteams, pagerduty |
+| VCS/CI/IaC | github, gitlab, terraform |
+| Ticketing | jira, servicenow |
+| Infrastructure | kubernetes-triage, vault |
+| MCP / Bridge | mcp-bridge, mcp-client, webhooks |
+| Reference / Standard | hello-pack, pic-standard, incident-enricher |
+| Automation / Guards | cron-triggers, langchain-guard (bundle-only) |
 
 ## Build & Publish
 
-- `tools/build.py` generates `public/catalog.json` + bundled packs
-- Published to `packs.cordum.io`
-- 26 git worktrees for parallel pack development
-
-## Development Workflow
-
-1. Pick a pack: `cd packs/<pack-name>`
-2. Check `deploy/env.example` for required credentials
-3. Build: `go build ./cmd/cordum-<pack>/`
-4. Test: `go test ./...`
-5. Run locally with NATS + Redis running (from `cordum` repo: `make dev-up`)
+- `tools/build.py` builds reproducible `pack.tgz` bundles (mtime/uid/gid zeroed), computes sha256 per bundle, verifies digests, and emits `public/catalog.json` + a stats page. Pack id/version come from `metadata`; capabilities/requires/riskTags are aggregated from `topics`.
+- The `publish.yml` GitHub Actions workflow builds `public/` and serves it via GitHub Pages at `packs.cordum.io` (`/catalog.json`, `/packs/<id>/<version>/pack.tgz`). Override the base URL with `PACKS_BASE_URL` / `--base-url`.
 
 ## Platform Notes
 
-- Windows/MSYS environment — use Unix shell syntax
-- Python: use `python` (not `python3`)
-- Each pack is an independent Go module — no workspace-level `go.mod`
+- Windows host; default shell is **PowerShell** (use `$env:VAR`, `$null`, `.venv\Scripts\Activate.ps1`). A Bash tool is available for POSIX one-liners.
+- Python: invoke as `python`.
+- Each Go pack is an independent module — there is no workspace `go.mod`; run Go commands from inside the pack directory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ python tools/pack_scaffold.py my-pack --title "My Pack" --description "..."
 
 ## Pack Structure
 
-```
+```text
 packs/<pack-name>/
 ├── pack/                       # the installable bundle (build.py also accepts pack.yaml at pack root)
 │   ├── pack.yaml               # manifest (see below)
@@ -112,7 +112,7 @@ Python package (PyPI distribution name `cordum-adapters`, import `cordum_agent_a
 | Cloud (bundle-only) | aws, azure, gcp |
 | Monitoring | datadog, opentelemetry, prometheus-query, sentry |
 | Communication | slack, msteams, pagerduty |
-| VCS/CI/IaC | github, gitlab, terraform |
+| VCS/CI/IaC | GitHub, gitlab, terraform |
 | Ticketing | jira, servicenow |
 | Infrastructure | kubernetes-triage, vault |
 | MCP / Bridge | mcp-bridge, mcp-client, webhooks |

--- a/packs/monday/fixtures/policy-simulations.json
+++ b/packs/monday/fixtures/policy-simulations.json
@@ -11,6 +11,11 @@
       "expectDecision": "ALLOW"
     },
     {
+      "name": "graphql_write_requires_approval",
+      "request": {"tenantId": "default", "topic": "job.monday.graphql.write", "riskTags": ["write", "graphql"]},
+      "expectDecision": "REQUIRE_APPROVAL"
+    },
+    {
       "name": "destructive_denied",
       "request": {"tenantId": "default", "topic": "job.monday.graphql.destructive", "riskTags": ["destructive", "graphql"]},
       "expectDecision": "DENY"

--- a/packs/monday/fixtures/policy-simulations.json
+++ b/packs/monday/fixtures/policy-simulations.json
@@ -1,0 +1,24 @@
+{
+  "simulations": [
+    {
+      "name": "read_allowed",
+      "request": {"tenantId": "default", "topic": "job.monday.board.read", "riskTags": ["read"]},
+      "expectDecision": "ALLOW"
+    },
+    {
+      "name": "status_update_allowed",
+      "request": {"tenantId": "default", "topic": "job.monday.status.update", "riskTags": ["write", "status_update"]},
+      "expectDecision": "ALLOW"
+    },
+    {
+      "name": "destructive_denied",
+      "request": {"tenantId": "default", "topic": "job.monday.graphql.destructive", "riskTags": ["destructive", "graphql"]},
+      "expectDecision": "DENY"
+    },
+    {
+      "name": "spoofed_destructive_still_denied",
+      "request": {"tenantId": "default", "topic": "job.monday.graphql.destructive", "riskTags": ["read"]},
+      "expectDecision": "DENY"
+    }
+  ]
+}

--- a/packs/monday/overlays/policy.fragment.yaml
+++ b/packs/monday/overlays/policy.fragment.yaml
@@ -1,0 +1,36 @@
+version: v1
+rules:
+  - id: monday-read-allow
+    match:
+      topics:
+        - job.monday.board.read
+        - job.monday.graphql.read
+      risk_tags:
+        - read
+    decision: allow
+    reason: "Monday read-only operations are allowed for the demo sandbox."
+
+  - id: monday-status-update-allow
+    match:
+      topics:
+        - job.monday.status.update
+      risk_tags:
+        - status_update
+    decision: allow
+    reason: "Monday sandbox status-column updates are allowed."
+
+  - id: monday-destructive-deny
+    match:
+      topics:
+        - job.monday.graphql.destructive
+    decision: deny
+    reason: "Monday destructive GraphQL operations are denied unless a separate content-aware MCP gate explicitly allows them."
+
+  - id: monday-generic-write-review
+    match:
+      topics:
+        - job.monday.graphql.write
+      risk_tags:
+        - write
+    decision: require_approval
+    reason: "General Monday GraphQL writes require human approval."

--- a/packs/monday/overlays/pools.patch.yaml
+++ b/packs/monday/overlays/pools.patch.yaml
@@ -1,0 +1,10 @@
+topics:
+  job.monday.board.read: monday
+  job.monday.status.update: monday
+  job.monday.graphql.read: monday
+  job.monday.graphql.write: monday
+  job.monday.graphql.destructive: monday
+pools:
+  monday:
+    requires:
+      - "network:egress"

--- a/packs/monday/overlays/timeouts.patch.yaml
+++ b/packs/monday/overlays/timeouts.patch.yaml
@@ -1,0 +1,16 @@
+topics:
+  job.monday.board.read:
+    timeout_seconds: 30
+    max_retries: 2
+  job.monday.status.update:
+    timeout_seconds: 30
+    max_retries: 2
+  job.monday.graphql.read:
+    timeout_seconds: 30
+    max_retries: 2
+  job.monday.graphql.write:
+    timeout_seconds: 30
+    max_retries: 1
+  job.monday.graphql.destructive:
+    timeout_seconds: 30
+    max_retries: 0

--- a/packs/monday/pack.yaml
+++ b/packs/monday/pack.yaml
@@ -1,0 +1,99 @@
+apiVersion: cordum.io/v1alpha1
+kind: Pack
+
+metadata:
+  id: monday
+  version: 0.1.0
+  title: Monday.com
+  description: >
+    Monday.com policy and topic bundle for governing board reads, status-column
+    updates, and server-classified destructive GraphQL operations.
+
+compatibility:
+  protocolVersion: 1
+  minCoreVersion: 0.6.0
+
+topics:
+  - name: job.monday.board.read
+    capability: monday.board.read
+    inputSchema: monday/BoardReadInput
+    outputSchema: monday/BoardReadOutput
+    riskTags: ["read"]
+    requires: ["network:egress"]
+
+  - name: job.monday.status.update
+    capability: monday.status.update
+    inputSchema: monday/StatusUpdateInput
+    outputSchema: monday/StatusUpdateOutput
+    riskTags: ["write", "status_update"]
+    requires: ["network:egress"]
+
+  - name: job.monday.graphql.read
+    capability: monday.graphql.read
+    inputSchema: monday/GraphQLInput
+    outputSchema: monday/GraphQLOutput
+    riskTags: ["read", "graphql"]
+    requires: ["network:egress"]
+
+  - name: job.monday.graphql.write
+    capability: monday.graphql.write
+    inputSchema: monday/GraphQLInput
+    outputSchema: monday/GraphQLOutput
+    riskTags: ["write", "graphql"]
+    requires: ["network:egress"]
+
+  - name: job.monday.graphql.destructive
+    capability: monday.graphql.destructive
+    inputSchema: monday/GraphQLInput
+    outputSchema: monday/GraphQLOutput
+    riskTags: ["destructive", "graphql"]
+    requires: ["network:egress"]
+
+resources:
+  schemas:
+    - id: monday/BoardReadInput
+      path: schemas/BoardReadInput.json
+    - id: monday/BoardReadOutput
+      path: schemas/BoardReadOutput.json
+    - id: monday/StatusUpdateInput
+      path: schemas/StatusUpdateInput.json
+    - id: monday/StatusUpdateOutput
+      path: schemas/StatusUpdateOutput.json
+    - id: monday/GraphQLInput
+      path: schemas/GraphQLInput.json
+    - id: monday/GraphQLOutput
+      path: schemas/GraphQLOutput.json
+  workflows: []
+
+overlays:
+  policy:
+    - name: monday
+      strategy: bundle_fragment
+      path: overlays/policy.fragment.yaml
+
+tests:
+  policySimulations:
+    - name: read_allowed
+      request:
+        tenantId: default
+        topic: job.monday.board.read
+        riskTags: ["read"]
+      expectDecision: ALLOW
+    - name: status_update_allowed
+      request:
+        tenantId: default
+        topic: job.monday.status.update
+        riskTags: ["write", "status_update"]
+      expectDecision: ALLOW
+    - name: destructive_denied
+      request:
+        tenantId: default
+        topic: job.monday.graphql.destructive
+        riskTags: ["destructive", "graphql"]
+      expectDecision: DENY
+    - name: spoofed_destructive_still_denied
+      request:
+        tenantId: default
+        topic: job.monday.graphql.destructive
+        riskTags: ["read"]
+      expectDecision: DENY

--- a/packs/monday/pack.yaml
+++ b/packs/monday/pack.yaml
@@ -98,6 +98,12 @@ tests:
         topic: job.monday.status.update
         riskTags: ["write", "status_update"]
       expectDecision: ALLOW
+    - name: graphql_write_requires_approval
+      request:
+        tenantId: default
+        topic: job.monday.graphql.write
+        riskTags: ["write", "graphql"]
+      expectDecision: REQUIRE_APPROVAL
     - name: destructive_denied
       request:
         tenantId: default

--- a/packs/monday/pack.yaml
+++ b/packs/monday/pack.yaml
@@ -63,9 +63,22 @@ resources:
       path: schemas/GraphQLInput.json
     - id: monday/GraphQLOutput
       path: schemas/GraphQLOutput.json
-  workflows: []
+  workflows:
+    - id: monday.board-read
+      path: workflows/board_read.yaml
 
 overlays:
+  config:
+    - name: pools
+      scope: system
+      key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+    - name: timeouts
+      scope: system
+      key: timeouts
+      strategy: json_merge_patch
+      path: overlays/timeouts.patch.yaml
   policy:
     - name: monday
       strategy: bundle_fragment

--- a/packs/monday/schemas/BoardReadInput.json
+++ b/packs/monday/schemas/BoardReadInput.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["boardId"],
+  "properties": {
+    "boardId": {"type": ["string", "integer"]},
+    "includeColumns": {"type": "boolean", "default": true},
+    "limit": {"type": "integer", "minimum": 1, "maximum": 500}
+  },
+  "additionalProperties": false
+}

--- a/packs/monday/schemas/BoardReadOutput.json
+++ b/packs/monday/schemas/BoardReadOutput.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "board": {"type": "object"},
+    "items": {"type": "array", "items": {"type": "object"}},
+    "pagination": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/packs/monday/schemas/GraphQLInput.json
+++ b/packs/monday/schemas/GraphQLInput.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["query"],
+  "properties": {
+    "query": {"type": "string"},
+    "variables": {"type": ["string", "object", "null"]}
+  },
+  "additionalProperties": false
+}

--- a/packs/monday/schemas/GraphQLInput.json
+++ b/packs/monday/schemas/GraphQLInput.json
@@ -4,7 +4,7 @@
   "required": ["query"],
   "properties": {
     "query": {"type": "string"},
-    "variables": {"type": ["string", "object", "null"]}
+    "variables": {"type": ["object", "null"]}
   },
   "additionalProperties": false
 }

--- a/packs/monday/schemas/GraphQLOutput.json
+++ b/packs/monday/schemas/GraphQLOutput.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "data": {"type": ["object", "null"]},
+    "errors": {"type": "array", "items": {"type": "object"}}
+  },
+  "additionalProperties": true
+}

--- a/packs/monday/schemas/StatusUpdateInput.json
+++ b/packs/monday/schemas/StatusUpdateInput.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["boardId", "itemId", "columnValues"],
+  "properties": {
+    "boardId": {"type": ["string", "integer"]},
+    "itemId": {"type": ["string", "integer"]},
+    "columnValues": {"type": ["string", "object"]}
+  },
+  "additionalProperties": false
+}

--- a/packs/monday/schemas/StatusUpdateOutput.json
+++ b/packs/monday/schemas/StatusUpdateOutput.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "message": {"type": "string"},
+    "item_id": {"type": "string"},
+    "item_name": {"type": "string"},
+    "item_url": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/packs/monday/workflows/board_read.yaml
+++ b/packs/monday/workflows/board_read.yaml
@@ -1,0 +1,24 @@
+id: monday.board-read
+name: Monday Board Read
+description: Read a Monday.com board through a single governed worker step.
+version: "0.1.0"
+timeout_sec: 30
+steps:
+  read:
+    id: read
+    name: Read board
+    type: worker
+    topic: job.monday.board.read
+    input:
+      boardId: ${input.boardId}
+      includeColumns: ${input.includeColumns}
+      limit: ${input.limit}
+    input_schema_id: monday/BoardReadInput
+    output_schema_id: monday/BoardReadOutput
+    meta:
+      pack_id: monday
+      capability: monday.board.read
+      risk_tags:
+        - read
+      requires:
+        - "network:egress"


### PR DESCRIPTION
Adds the Monday.com integration pack for the Cordum x Monday demo (Monday CAP worker / policy fragment).

Commits vs main:
- feat(monday): add Monday integration pack
- docs: CLAUDE.md checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Monday.com integration pack with support for board operations, status updates, and GraphQL queries, including access control policies for read, write, and destructive operations.

* **Documentation**
  * Revised development guide with updated pack structure guidance, Go module layout, comprehensive build and test workflows, platform execution instructions, and bundle publishing guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum-packs/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->